### PR TITLE
修正by_fake_find_maps打开的so可能没有执行属性的bug

### DIFF
--- a/src/native/byopen_android.c
+++ b/src/native/byopen_android.c
@@ -92,6 +92,8 @@ static by_pointer_t by_fake_find_maps(by_char_t const* filename, by_char_t* real
 
     // find it
     by_char_t    line[512];
+    by_char_t page_attr[512];
+    page_attr[0] = 0;
     by_pointer_t baseaddr = by_null;
     FILE* fp = fopen("/proc/self/maps", "r");
     if (fp)
@@ -103,8 +105,10 @@ static by_pointer_t by_fake_find_maps(by_char_t const* filename, by_char_t* real
                 int       pos = 0;
                 uintptr_t start = 0;
                 uintptr_t offset = 0;
-                if (2 == sscanf(line, "%"SCNxPTR"-%*"SCNxPTR" %*4s %"SCNxPTR" %*x:%*x %*d%n", &start, &offset, &pos) && !offset)
+                //不知道为什么在我的一台安卓7上面 不能使用 %c%cx%c 过滤，所以用了这个投机取巧的办法
+                if (3 == sscanf(line, "%"SCNxPTR"-%*"SCNxPTR" %4s %"SCNxPTR" %*x:%*x %*d%n", &start,page_attr, &offset, &pos) && !offset)
                 {
+                    if (page_attr[2] != 'x')continue;
                     baseaddr = (by_pointer_t)start;
                     if (filename[0] == '/')
                         strlcpy(realpath, filename, realmaxn);

--- a/src/native/byopen_android.c
+++ b/src/native/byopen_android.c
@@ -92,7 +92,7 @@ static by_pointer_t by_fake_find_maps(by_char_t const* filename, by_char_t* real
 
     // find it
     by_char_t    line[512];
-    by_char_t    page_attr[512];
+    by_char_t    page_attr[10];
     by_pointer_t baseaddr = by_null;
     FILE* fp = fopen("/proc/self/maps", "r");
     if (fp)

--- a/src/native/byopen_android.c
+++ b/src/native/byopen_android.c
@@ -104,7 +104,7 @@ static by_pointer_t by_fake_find_maps(by_char_t const* filename, by_char_t* real
                 int       pos = 0;
                 uintptr_t start = 0;
                 uintptr_t offset = 0;
-                if (3 == sscanf(line, "%"SCNxPTR"-%*"SCNxPTR" %4s %"SCNxPTR" %*x:%*x %*d%n", &start,page_attr, &offset, &pos) && !offset)
+                if (3 == sscanf(line, "%"SCNxPTR"-%*"SCNxPTR" %4s %"SCNxPTR" %*x:%*x %*d%n", &start, page_attr, &offset, &pos) && !offset)
                 {
                     if (page_attr[2] != 'x') continue;
                     baseaddr = (by_pointer_t)start;

--- a/src/native/byopen_android.c
+++ b/src/native/byopen_android.c
@@ -92,8 +92,7 @@ static by_pointer_t by_fake_find_maps(by_char_t const* filename, by_char_t* real
 
     // find it
     by_char_t    line[512];
-    by_char_t page_attr[512];
-    page_attr[0] = 0;
+    by_char_t    page_attr[512];
     by_pointer_t baseaddr = by_null;
     FILE* fp = fopen("/proc/self/maps", "r");
     if (fp)
@@ -105,10 +104,9 @@ static by_pointer_t by_fake_find_maps(by_char_t const* filename, by_char_t* real
                 int       pos = 0;
                 uintptr_t start = 0;
                 uintptr_t offset = 0;
-                //不知道为什么在我的一台安卓7上面 不能使用 %c%cx%c 过滤，所以用了这个投机取巧的办法
                 if (3 == sscanf(line, "%"SCNxPTR"-%*"SCNxPTR" %4s %"SCNxPTR" %*x:%*x %*d%n", &start,page_attr, &offset, &pos) && !offset)
                 {
-                    if (page_attr[2] != 'x')continue;
+                    if (page_attr[2] != 'x') continue;
                     baseaddr = (by_pointer_t)start;
                     if (filename[0] == '/')
                         strlcpy(realpath, filename, realmaxn);


### PR DESCRIPTION
在有些设备上的maps文件会存在 可执行的so没有映射到最前面的那行，而是在后面的几行，所以会导致得到的so基址是错误的

------

在sscanf中加入对内存属性的判断，只读取有可执行权限的so的基地址

